### PR TITLE
feat: Clarify that methods on CommonSorting should be non-destructive.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,4 +2,5 @@
   - Place: Venice (IT), London (UK)
   - About: Guardian of the Tannhäuser Gate
   - Website: http://torre.me.uk
-
+- [megri](https://github.com/megri)
+  - Place: Gothenburg (SE)

--- a/src/main/scala/io/github/sentenza/hacktoberfest18/sort/CommonSortings.scala
+++ b/src/main/scala/io/github/sentenza/hacktoberfest18/sort/CommonSortings.scala
@@ -16,6 +16,12 @@ package io.github.sentenza.hacktoberfest18.sort
  */
 
 object CommonSortings {
+  /* 
+   * Implementations of this trait should provide non-destructive sort
+   * operations on arrays. That is, the array passed to a sort method
+   * should not be altered: A new array with the sorted values should be
+   * returned.
+   */
   trait CommonSorting {
     def bubbleSort(array: Array[Int]): Array[Int]
     def selectionSort(array: Array[Int]): Array[Int]


### PR DESCRIPTION
I added a small comment to the CommonSorting trait. I assume it's meant to return a new array rather than modifying the passed one.