### PR TITLE
Add Immutable Sorts, Immutable Bubble Sort Implementation

### DIFF
--- a/src/main/scala/io/github/sentenza/hacktoberfest18/algos/ImmutableSorting.scala
+++ b/src/main/scala/io/github/sentenza/hacktoberfest18/algos/ImmutableSorting.scala
@@ -1,0 +1,126 @@
+package io.github.sentenza.hacktoberfest18.algos
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+
+/*
+ * HacktoberFest 2018 - Scala Algorhitms
+ * Copyright (C) 2018 sentenza
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+  * Implementations of this trait should provide non-destructive sort
+  * operations on lists, returning a sorted copy of the provided input list.
+  */
+object ImmutableSorting extends Sorting[List, Int] {
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def bubbleSort(xs: List[Int]): List[Int] = {
+    def bubbled(list: List[Int]): (List[Int], Boolean) = list match {
+      case Nil => (Nil, false)
+      case elem :: rest => rest match {
+        case Nil => (elem :: Nil, false)
+        case secondElem :: _ if elem <= secondElem => {
+          val (restBubbled, swapped) = bubbled(rest)
+
+          (elem :: restBubbled, swapped)
+        }
+        case secondElem :: secondRest => {
+          val (restBubbled, swapped) = bubbled(elem :: secondRest)
+
+          (secondElem :: restBubbled, true)
+        }
+      }
+    }
+
+    val (fullyBubbled, _) = List.fill(xs.size)(()).foldLeft[(List[Int], Boolean)]((xs, true)) {
+      case (done @ (_, false), _) => done // There were no swaps in the last iteration, so short-circuit
+      case ((lastList, true), _) => bubbled(lastList)
+    }
+
+    fullyBubbled
+  }
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def cocktailShakerSort(xs: List[Int]): List[Int] = ???
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def combSort(xs: List[Int]): List[Int] = ???
+
+  /** @inheritdoc
+    * @param list List of sortable integers
+    * @return The sorted list
+    */
+  def insertionSort(list: List[Int]): List[Int] = ???
+
+  /** @inheritdoc
+    * @param list List of sortable integers
+    * @return The sorted list
+    */
+  def selectionSort(list: List[Int]): List[Int] = ???
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def heapSort(xs: List[Int]): List[Int] = ???
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def quickSort(list: List[Int]): List[Int] = ???
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def mergeSort(list: List[Int]): List[Int] = ???
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def bucketSort(xs: List[Int],
+                 n: Int = 10,
+                 sort: List[Int] => List[Int] = insertionSort): List[Int] = ???
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def countSort(xs: List[Int]): List[Int] = ???
+
+  /** @inheritdoc
+    *
+    * @param xs List of sortable Integers
+    * @return The sorted list
+    */
+  def radixSort(xs: List[Int]): List[Int] = ???
+}

--- a/src/test/scala/io/github/sentenza/hacktoberfest18/algos/ImmutableSortingSpec.scala
+++ b/src/test/scala/io/github/sentenza/hacktoberfest18/algos/ImmutableSortingSpec.scala
@@ -1,0 +1,43 @@
+package io.github.sentenza.hacktoberfest18.algos
+
+import io.github.sentenza.hacktoberfest18.util.ListUtil
+import org.scalatest.{Matchers, WordSpec}
+import ImmutableSorting._
+import scala.util.Random
+
+class ImmutableSortingSpec extends WordSpec with Matchers {
+  /**
+    * The default length of the arrays that will be generated in this spec.
+    */
+  private val random = new Random()
+  private val defaultLength = Math.max(100, random.nextInt(1000))
+  private val listUtil = new ListUtil()
+  private val randomIndices = List.fill(5)(random.nextInt(defaultLength)).distinct
+
+  /**
+    * Helper method that returns a couple of array (unsorted, sorted).
+    *
+    * @param l The length of the array that will be generated
+    * @return (unsortedArray, sortedArray)
+    */
+  private def getLists(l: Int): (List[Int], List[Int]) = {
+    val randomUnsortedList = listUtil.buildRandomList(l)
+    (randomUnsortedList, randomUnsortedList.sorted)
+  }
+
+  /* creates a random array and set of random indices, and applies the algorithm,
+   * comparing the result with a value lifted from the sorted version
+   */
+  private def compareAfterSortingWith(algo: List[Int] => List[Int]) = {
+    val (unsorted, sorted) = getLists(defaultLength)
+
+    algo(unsorted) shouldBe sorted
+  }
+
+  "ImmutableSorting" should {
+
+    "sort a list using the Bubble sort algorithm" in {
+      compareAfterSortingWith(bubbleSort)
+    }
+  }
+}


### PR DESCRIPTION
Add an implementation of bubble sort which uses only immutable lists and
no mutable variables to achieve a sort.

Add a spec for immutable sorts, and add the new sort algorithm to the
spec.