### PR TITLE
Add tree map

### DIFF
--- a/src/main/scala/io/github/sentenza/hacktoberfest/adt/Tree.scala
+++ b/src/main/scala/io/github/sentenza/hacktoberfest/adt/Tree.scala
@@ -52,12 +52,16 @@ object Tree {
   }
 
   /**
+    * Returns a Tree with all the values replaced with the given function
     * @param tree The tree to work on
     * @param f The function to be applied to each leaf of the Tree
     * @tparam F The type of the element that will be returned by f
     * @return A new Tree which will be made by applying f to the original Tree
     */
-  def map[T, F](tree: Tree[T], f: T => F): Tree[F] = ???
+  def map[T, F](tree: Tree[T], f: (T) => F): Tree[F] = tree match {
+    case Leaf(v) => Leaf(f(v))
+    case Branch(l, r) => Branch(map(l, f), map(r, f))
+  }
 
   //  def maximum[T](): T = ???
 }

--- a/src/test/scala/io/github/sentenza/hacktoberfest/adt/TreeSpec.scala
+++ b/src/test/scala/io/github/sentenza/hacktoberfest/adt/TreeSpec.scala
@@ -20,6 +20,17 @@ class TreeSpec extends WordSpec with Matchers {
       )
       Tree.depth(testTree) shouldBe 2
     }
+
+    "have a map() method to replace the tree values" in {
+      val testTree = Branch(
+        Branch(Leaf(1), Leaf(3)),
+        Branch(Leaf(2), Leaf(4))
+      )
+      Tree.map(testTree, (x: Int) => x + 1) shouldBe Branch(
+        Branch(Leaf(2), Leaf(4)),
+        Branch(Leaf(3), Leaf(5))
+      )
+    }
   }
 
   "Tree.depth()" should {
@@ -61,6 +72,25 @@ class TreeSpec extends WordSpec with Matchers {
       )
       Tree.depth(treeD5) shouldBe 5
     }
+  }
 
+  "Tree.map()" should {
+    "work when there's only a Leaf" in {
+      Tree.map(Leaf(1), (x: Int) => x * 2) shouldBe Leaf(2)
+    }
+
+    "be independent of the tree depth" in {
+      Tree.map(
+        Branch(Branch(Branch(Leaf(1), Leaf(2)), Leaf(3)), Leaf(4)),
+        (x: Int) => x - 1
+      ) shouldBe Branch(Branch(Branch(Leaf(0), Leaf(1)), Leaf(2)), Leaf(3))
+    }
+
+    "work across types" in {
+      Tree.map(
+        Branch(Leaf(1), Branch(Leaf(2), Leaf(3))),
+        (x: Int) => x * Math.PI
+      ) shouldBe Branch(Leaf(Math.PI), Branch(Leaf(2 * Math.PI), Leaf(3 * Math.PI)))
+    }
   }
 }


### PR DESCRIPTION
Fixes #31 .

Adds the implementation of the map method to the Tree, along with its tests.


### Notes 
The implementation is a straightforward recursive algorithm.

### Test Instructions 
The tests check for some edge-cases like:
- A "Tree" with only a leaf
- A general tree
- Changing between data types

